### PR TITLE
remove constants.xlf

### DIFF
--- a/environment/test/Plugins/Environment.bundle/Contents/Resources/constants.xlf
+++ b/environment/test/Plugins/Environment.bundle/Contents/Resources/constants.xlf
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<xliff version="1.0" xmlns:d4="http://www.4d.com/d4-ns">
-    <header>
-        <note>Environment</note>
-    </header>
-</xliff>


### PR DESCRIPTION
Remove empty constants.xlf that causes compilation errors on Windows when running as a service.

I'm not entirely sure how to produce the new `.dmg` and `.zip` artifacts or I would-- Let me know if I can help further here!